### PR TITLE
プロフィール画像にユーザー詳細ページのリンクを追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,4 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   validates :name, presence: true, uniqueness: true

--- a/app/views/posts/_post.html.haml
+++ b/app/views/posts/_post.html.haml
@@ -3,10 +3,11 @@
   .user_timeline
     .name_timeline
       - if !post.user.image.blank?
-        %img{src: post.user.image, class: 'icon_image_feed'}
+        = link_to image_tag(post.user.image.url, class: 'icon_image_feed'), post.user
       - else
-        = image_tag 'usericon.png', class: 'icon_image_feed'
-      %span.user_name= link_to post.user.name, post.user
+        = link_to image_tag('usericon.png', class: 'icon_image_feed'), post.user
+      %span.user_name
+        = link_to post.user.name, post.user
     .favo_timeline
       %span{id: "favo_form_#{post.id}"}
         - if post.favoed_by.include?(current_user)

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -5,9 +5,9 @@
     .user_timeline
       .name_timeline
         - if !@post.user.image.blank?
-          %img{src: @post.user.image, class: 'icon_image_feed'}
+          = link_to image_tag(@post.user.image.url, class: 'icon_image_feed'), @post.user
         - else
-          = image_tag 'usericon.png', class: 'icon_image_feed'
+          = link_to image_tag('usericon.png', class: 'icon_image_feed'), @post.user
         %span.user_name= link_to @post.user.name, @post.user
       .favo_timeline
         %span{id: "favo_form_#{@post.id}"}
@@ -21,7 +21,7 @@
     - else
       = video_tag @post.picture.url, width: "100%", height: "100%", controls: true, autobuffer: true                            
     / いいね
-    %span{:id => "like_form_#{@post.id}"}
+    %span{id: "like_form_#{@post.id}"}
       - if @post.liked_by.include?(current_user)
         = render "posts/unlike", post: @post
       - else

--- a/app/views/rooms/show.html.haml
+++ b/app/views/rooms/show.html.haml
@@ -7,7 +7,7 @@
           Member:
           - @entries.each do |e|
             %strong
-              %a{:href => "/users/#{e.user.id}"}= e.user.name
+              %a{href: "/users/#{e.user.id}"}= e.user.name
         = form_with model: @message, local: true do |f|
           .dm_form
             .form-item

--- a/app/views/shared/_user_info.html.haml
+++ b/app/views/shared/_user_info.html.haml
@@ -2,7 +2,7 @@
 .user_top
   %h1
     - if !@user.image.blank?
-      %img{src: @user.image, class: 'icon_image_prof'}
+      = image_tag(@user.image.url, class: 'icon_image_prof')
     - else
       = image_tag 'usericon.png', class: 'icon_image_prof'
     = @user.name

--- a/app/views/shared/_user_info.html.haml
+++ b/app/views/shared/_user_info.html.haml
@@ -11,7 +11,7 @@
   / ダイレクトメッセージ
   - unless @user.id == current_user.id
     - if @isRoom == true
-      %a.fas.fa-envelope.fa_icon2{:href => "/rooms/#{@roomId}"}
+      %a.fas.fa-envelope.fa_icon2{href: "/rooms/#{@roomId}"}
     - else
       = form_with model: @room do |f|
         = fields_for @entry do |e|

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -1,8 +1,8 @@
 %li
   - unless user == current_user
     - if user.image.blank?
-      = image_tag 'usericon.png', class: 'icon_image_prof'
+      = link_to image_tag('usericon.png', class: 'icon_image_prof'), user
     - else
-      %img{src: user.image, class: 'icon_image_prof'}
+      = link_to image_tag(user.image.url, class: 'icon_image_prof'), user
     = link_to user.name, user
 


### PR DESCRIPTION
# What
プロフィール画像にユーザー詳細ページのリンクを追加した。

# Why
タイムライン等にプロフィール画像とユーザー名を表示し、ユーザー名のみに詳細ページへのリンクを設定していた。
プロフィール画像にも同様のリンクがある方が、より直感的にユーザーが操作しやすいので修正を行った。