### PR TITLE
記事投稿時のファイルサイズ上限を修正

### DIFF
--- a/app/views/shared/_post_form.html.haml
+++ b/app/views/shared/_post_form.html.haml
@@ -8,11 +8,3 @@
         #picture_file
           = f.file_field :picture, accept: 'image/jpeg,image/gif,image/png,video/*'
   = f.submit "投稿する", class: "btn_post"
-  
-:javascript
-  $('#post_picture').bind('change', function () {
-    var size_in_megabytes = this.files[0].size / 1024 / 1024;
-    if (size_in_megabytes > 5) {
-      alert('Maximum file size is 5MB. Please choose a smaller file.');
-    }
-  });


### PR DESCRIPTION
# What
記事投稿時30MBまでをサイズ上限にしていたが、5MBでアラートが出る記述があったので削除した。

# Why
サイズ上限を30MBまでにする事で、1分程度の動画ファイルをアップロードできる様にする為。