### PR TITLE
CircleCIとCapistranoを使用した自動デプロイを設定を修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
                               
       - add_ssh_keys:
           fingerprints:
-            - "43:20:c9:f7:80:d9:89:e2:fc:b0:14:80:89:84:3d:4e"
+            - "25:df:bd:91:ed:07:50:de:c9:31:6f:b4:f4:d7:6f:8d"
 
       - deploy:
           name: Capistrano deploy

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@
 - MySQL 5.6
 - nginx 1.16.1
 - Docker, docker-compose
-- CircleCI/CD(Capistrano)
+- CircleCI, Capistrano (CI/CD)
 
 ## API
 - Google Maps JavaScript


### PR DESCRIPTION
# What
CircleCIとCapistranoを使用した自動デプロイを設定を修正

# Why
fingerprintsの記載が間違っていたのでマージ後自動デプロイされなかった為