### PR TITLE
ヘッダーにユーザー一覧へのリンクを追加

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -111,7 +111,6 @@ aside {
 
 .users2{
   list-style: none;
-  width: 20%;
 }
 
 .btn_dm{

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -9,9 +9,11 @@
               = link_to current_user , method: :get do
                 %i.fas.fa-user.fa_icon
             %li
-            %li
               = link_to main_pages_protection_path , method: :get do
                 %i.fas.fa-cat.fa_icon
+            %li
+              = link_to users_path , method: :get do
+                %i.fas.fa-hands-helping.fa_icon
             %li
               - unless current_user.email == "guest@example.com"
                 = link_to edit_user_registration_path, method: :get do


### PR DESCRIPTION
# What
ヘッダーにユーザー一覧へのリンクを追加した

# Why
画面幅を狭くした時に、body内でユーザー一覧へのリンクを消すようにした。
その代わりにヘッダーにユーザー一覧へのリンクを追加し、検索できるようにした為。